### PR TITLE
Adds current contributors to the TC to team.md

### DIFF
--- a/Governance/Team.md
+++ b/Governance/Team.md
@@ -4,8 +4,9 @@ Anyone is welcome to contribute! Join the developer mailing list LINK and get st
 
 ## Committee Members
 
-* [**Name**](Twitter link) | [Github name](github link) | Email: something AT somewhere.thing
+* [**Kelsey Breseman**](http://twitter.com/selkeymoonbeam/) | [frijol](http://github.com/frijol) | Email: [kelsey@technical.io](mailto:kelsey@technical.io)
+* [**Tim Ryan**](http://twitter.com/timcameronryan/) | [tcr](http://github.com/tcr) | Email: [tim@technical.io](mailto:tim@technical.io)
 
 ## Moderators
 
-* [**Name**](Twitter link) | [Github name](github link)
+* [**Jon McKay**](http://twitter.com/jonmckay) | [johnnyman727](http://github.com/johnnyman727)


### PR DESCRIPTION
This may be temporary, but helps assuage the idea that we're proposing arbitrary changes to the doc without being members.
