### PR TITLE
Adds remaining Technical Machine members as transitional or moderators.

### DIFF
--- a/Governance/Team.md
+++ b/Governance/Team.md
@@ -10,6 +10,8 @@ Anyone is welcome to contribute! Join the developer mailing list LINK and get st
 
 ### Transitional
 
+These are de *facto* committee members for the duration of the initial structuring process, after which they will reevaluate their position to seek full nomination or abdicate their role, opting for moderatorship.
+
 * [**Jia Huang**](https://twitter.com/jia) | [jiahuang](http://github.com/jiahuang) | Email: [jia@technical.io](mailto:jia@technical.io)
 * [**Eric Kolker**](https://twitter.com/twiddlee) | [ekolker](http://github.com/ekolker) | Email: [e@technical.io](mailto:e@technical.io)
 * [**Kevin Mehall**](https://twitter.com/kevinmehall) | [kevinmehall](http://github.com/kevinmehall) | Email: [kevin@technical.io](mailto:kevin@technical.io)


### PR DESCRIPTION
I defined "transitional" members as being:

> I will be a committee member for the duration of the initial structuring process, after which I will reevaluate my position and become a full member, or abdicate my role.

The initial structuring process will end when we gain external members, open this work as public, or just reach consensus on the issue.

@nplus11 @HarleyKwyn @kevinmehall @jiahuang @ekolker 
