### PR TITLE
Code of Conduct Badge

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,5 +1,5 @@
-Code of Conduct
-===============
+Tessel Community Code of Conduct
+================================
 
 This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # <img src="https://cloud.githubusercontent.com/assets/80639/7736468/c78ac686-fef8-11e4-9931-cc3ef8fd37a0.png" width="600" alt="The Tessel Project">
 
+[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/tessel/project/blob/master/CONDUCT.md)
+
 **Looking for the entry point to the Tessel Project?**<br/>
 You've come to the right place. Read on.
 


### PR DESCRIPTION
Adds a badge linking to our code of conduct, can add to other pages as necessary.

[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/tessel/project/blob/master/CONDUCT.md)

[Rendered.](https://github.com/tessel/project/blob/8a68c44b9680c7d68121440599d4c87ac0ae1d7d/README.md)

(Also I feel like the Slack badge on README.md should be moved up but it's a minor aesthetic concern.)
